### PR TITLE
Switch to light color scheme

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,5 +1,34 @@
 /* Custom styles for Comfort Women News Aggregator */
 
+:root {
+    --main-bg: #ffffff;
+    --main-bg-alt: #bfdff2;
+    --accent-color: #fff4db;
+    --text-color: #000000;
+}
+
+body {
+    background-color: var(--main-bg);
+    color: var(--text-color);
+}
+
+.navbar,
+footer {
+    background-color: var(--main-bg-alt) !important;
+    color: var(--text-color);
+}
+
+.navbar-brand,
+.nav-link {
+    color: var(--text-color) !important;
+}
+
+.btn-primary {
+    background-color: var(--accent-color);
+    border-color: var(--accent-color);
+    color: var(--text-color);
+}
+
 /* Article content styling */
 .article-content {
     line-height: 1.7;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -102,6 +102,8 @@ function showAlert(message, type = 'info') {
     if (alertContainer && alertMessage) {
         // Update alert content
         alertMessage.className = `alert alert-${type} alert-dismissible fade show`;
+        alertMessage.style.backgroundColor = getComputedStyle(document.documentElement).getPropertyValue('--accent-color');
+        alertMessage.style.color = getComputedStyle(document.documentElement).getPropertyValue('--text-color');
         alertMessage.innerHTML = `
             ${message}
             <button type="button" class="btn-close" data-bs-dismiss="alert"></button>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="dark">
+<html lang="en" data-bs-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Comfort Women News Aggregator{% endblock %}</title>
     
     <!-- Bootstrap CSS with Replit theme -->
-    <link href="https://cdn.replit.com/agent/bootstrap-agent-dark-theme.min.css" rel="stylesheet">
+    <link href="https://cdn.replit.com/agent/bootstrap-agent-light-theme.min.css" rel="stylesheet">
     
     <!-- Font Awesome Icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
@@ -16,7 +16,7 @@
 </head>
 <body>
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <nav class="navbar navbar-expand-lg navbar-light" style="background-color: var(--main-bg-alt);">
         <div class="container">
             <a class="navbar-brand" href="{{ url_for('index') }}">
                 <i class="fas fa-newspaper me-2"></i>
@@ -78,7 +78,7 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-dark text-light mt-5 py-4">
+    <footer class="mt-5 py-4" style="background-color: var(--main-bg-alt); color: var(--text-color);">
         <div class="container">
             <div class="row">
                 <div class="col-md-8">


### PR DESCRIPTION
## Summary
- use Bootstrap light theme instead of dark
- add custom color variables for white/BFDFF2/FFF4DB
- update navigation and footer styles
- display alerts using the accent color

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865f0b433f48326bba685a8e4adbc73